### PR TITLE
Add simple .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*.pyc
+*.pyo
+__pycache__/
+venv/


### PR DESCRIPTION
Just ignores compiled Python files and a `venv` dir.