### PR TITLE
Do NOT add 'ordereddict' for Python 2.7 or later

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,8 @@ if sys.version_info[:2] < (2, 6):
 else:
     params['install_requires'] = ['ply']
 
-params['install_requires'].append('ordereddict')
+if sys.version_info[:2] < (2, 7):
+    params['install_requires'].append('ordereddict')
 
 doclines = [x.strip() for x in (__doc__ or '').split('\n') if x]
 


### PR DESCRIPTION
While

1. 'ordereddict' is required for Python 2.6 or earlier
2. The current code conflicts with the rule in requirements.txt

This is critical for installing this package via anaconda/miniconda. The `conda` supports making a conda recipe from a pypi package but because of this issue, the following procedure raises an exception (while `ordereddict` conflicts with `python2.7` and installing packages without using conda recipe is not allowed within `conda build` procedure).

```sh
conda install -n root conda-build
conda skeleton pypi --python-version 2.7 pysmi
# Add '# [py26]' to 'ordereddict' lines in 'pysmi/meta.yml' here to ignore 'ordereddict' in Python 2.7 or later
conda build --python 2.7 pysmi
...
RuntimeError: Setuptools downloading is disabled in conda build ......
```

This PR is mainly for fixing that issue.

After this PR, `pip freeze` after `pip install .` on `pysmi` directory will show

```
# Python 2.6
appdirs==1.4.3
argparse==1.4.0
ordereddict==1.1
packaging==16.8
ply==3.10
pyparsing==2.2.0
pysmi==0.1.0
six==1.10.0

# Python 2.7
appdirs==1.4.3
packaging==16.8
ply==3.10
pyparsing==2.2.0
pysmi==0.1.0
six==1.10.0
```