### PR TITLE
The pysnmp backend not to produce over 255 args in function calls

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,8 @@ Revision 0.1.5, XX-10-2017
 --------------------------
 
 - Sphinx documentation theme changed to Alabaster
+- Multiple fixes to pysnmp codegen not to produce function calls
+  with more than 255 parameters
 
 Revision 0.1.4, 14-10-2017
 --------------------------

--- a/pysmi/codegen/pysnmp.py
+++ b/pysmi/codegen/pysnmp.py
@@ -405,11 +405,11 @@ class PySnmpCodeGen(AbstractCodeGen):
 
                 outStr += """
 for _%(name)s_obj in [%(objects)s]:
-    if pysnmp_version < (4, 4, 2):
+    if getattr(mibBuilder, 'version', 0) < (4, 4, 2):
         # WARNING: leading objects get lost here! Upgrade your pysnmp version!
         %(name)s = %(name)s.setObjects(*_%(name)s_obj)
     else:
-        %(name)s = %(name)s.setObjects(*_%(name)s_obj, append=False)
+        %(name)s = %(name)s.setObjects(*_%(name)s_obj, **dict(append=False))
 
 """ % dict(name=name, objects=', '.join(objStrParts))
 
@@ -455,11 +455,11 @@ for _%(name)s_obj in [%(objects)s]:
 
                 outStr += """
 for _%(name)s_obj in [%(objects)s]:
-    if pysnmp_version < (4, 4, 2):
+    if getattr(mibBuilder, 'version', 0) < (4, 4, 2):
         # WARNING: leading objects get lost here! Upgrade your pysnmp version!
         %(name)s = %(name)s.setObjects(*_%(name)s_obj)
     else:
-        %(name)s = %(name)s.setObjects(*_%(name)s_obj, append=False)
+        %(name)s = %(name)s.setObjects(*_%(name)s_obj, **dict(append=False))
 
 """ % dict(name=name, objects=', '.join(objStrParts))
 
@@ -504,11 +504,11 @@ for _%(name)s_obj in [%(objects)s]:
 
                 outStr += """
 for _%(name)s_obj in [%(objects)s]:
-    if pysnmp_version < (4, 4, 2):
+    if getattr(mibBuilder, 'version', 0) < (4, 4, 2):
         # WARNING: leading objects get lost here!
         %(name)s = %(name)s.setObjects(*_%(name)s_obj)
     else:
-        %(name)s = %(name)s.setObjects(*_%(name)s_obj, append=False)
+        %(name)s = %(name)s.setObjects(*_%(name)s_obj, **dict(append=False))
 
 """ % dict(name=name, objects=', '.join(objStrParts))
 
@@ -625,11 +625,11 @@ for _%(name)s_obj in [%(objects)s]:
 
                 outStr += """
 for _%(name)s_obj in [%(objects)s]:
-    if pysnmp_version < (4, 4, 2):
+    if getattr(mibBuilder, 'version', 0) < (4, 4, 2):
         # WARNING: leading objects get lost here! Upgrade your pysnmp version!
         %(name)s = %(name)s.setObjects(*_%(name)s_obj)
     else:
-        %(name)s = %(name)s.setObjects(*_%(name)s_obj, append=False)
+        %(name)s = %(name)s.setObjects(*_%(name)s_obj, **dict(append=False))
 
 """ % dict(name=name, objects=', '.join(objStrParts))
 
@@ -726,11 +726,11 @@ for _%(name)s_obj in [%(objects)s]:
 
             outStr += """
 for _%(name)s_obj in [%(objects)s]:
-    if pysnmp_version < (4, 4, 2):
+    if getattr(mibBuilder, 'version', 0) < (4, 4, 2):
         # WARNING: leading objects get lost here! Upgrade your pysnmp version!
         %(name)s = %(name)s.setObjects(*_%(name)s_obj)
     else:
-        %(name)s = %(name)s.setObjects(*_%(name)s_obj, append=False)
+        %(name)s = %(name)s.setObjects(*_%(name)s_obj, **dict(append=False))
 
 """ % dict(name=name, objects=', '.join(objStrParts))
 
@@ -1141,8 +1141,6 @@ for _%(name)s_obj in [%(objects)s]:
             out += self._out[sym]
 
         out += self.genExports()
-
-        out = '\nfrom pysnmp import __version__ as pysnmp_version\n\n' + out
 
         if 'comments' in kwargs:
             out = ''.join(['# %s\n' % x for x in kwargs['comments']]) + '#\n' + out

--- a/pysmi/codegen/pysnmp.py
+++ b/pysmi/codegen/pysnmp.py
@@ -409,7 +409,7 @@ for _%(name)s_obj in [%(objects)s]:
         # WARNING: leading objects get lost here! Upgrade your pysnmp version!
         %(name)s = %(name)s.setObjects(*_%(name)s_obj)
     else:
-        %(name)s = %(name)s.setObjects(*_%(name)s_obj, **dict(append=False))
+        %(name)s = %(name)s.setObjects(*_%(name)s_obj, **dict(append=True))
 
 """ % dict(name=name, objects=', '.join(objStrParts))
 
@@ -459,7 +459,7 @@ for _%(name)s_obj in [%(objects)s]:
         # WARNING: leading objects get lost here! Upgrade your pysnmp version!
         %(name)s = %(name)s.setObjects(*_%(name)s_obj)
     else:
-        %(name)s = %(name)s.setObjects(*_%(name)s_obj, **dict(append=False))
+        %(name)s = %(name)s.setObjects(*_%(name)s_obj, **dict(append=True))
 
 """ % dict(name=name, objects=', '.join(objStrParts))
 
@@ -508,7 +508,7 @@ for _%(name)s_obj in [%(objects)s]:
         # WARNING: leading objects get lost here!
         %(name)s = %(name)s.setObjects(*_%(name)s_obj)
     else:
-        %(name)s = %(name)s.setObjects(*_%(name)s_obj, **dict(append=False))
+        %(name)s = %(name)s.setObjects(*_%(name)s_obj, **dict(append=True))
 
 """ % dict(name=name, objects=', '.join(objStrParts))
 
@@ -629,7 +629,7 @@ for _%(name)s_obj in [%(objects)s]:
         # WARNING: leading objects get lost here! Upgrade your pysnmp version!
         %(name)s = %(name)s.setObjects(*_%(name)s_obj)
     else:
-        %(name)s = %(name)s.setObjects(*_%(name)s_obj, **dict(append=False))
+        %(name)s = %(name)s.setObjects(*_%(name)s_obj, **dict(append=True))
 
 """ % dict(name=name, objects=', '.join(objStrParts))
 
@@ -730,7 +730,7 @@ for _%(name)s_obj in [%(objects)s]:
         # WARNING: leading objects get lost here! Upgrade your pysnmp version!
         %(name)s = %(name)s.setObjects(*_%(name)s_obj)
     else:
-        %(name)s = %(name)s.setObjects(*_%(name)s_obj, **dict(append=False))
+        %(name)s = %(name)s.setObjects(*_%(name)s_obj, **dict(append=True))
 
 """ % dict(name=name, objects=', '.join(objStrParts))
 

--- a/pysmi/codegen/pysnmp.py
+++ b/pysmi/codegen/pysnmp.py
@@ -397,10 +397,24 @@ class PySnmpCodeGen(AbstractCodeGen):
 
             numFuncCalls = len(objects) // 255 + 1
 
-            for idx in range(numFuncCalls):
-                outStr += '.setObjects(' + ', '.join(objects[255 * idx:255 * (idx + 1)]) + ')'
+            if numFuncCalls > 1:
+                objStrParts = []
 
-            outStr += '\n'
+                for idx in range(numFuncCalls):
+                    objStrParts.append('[' + ', '.join(objects[255 * idx:255 * (idx + 1)]) + ']')
+
+                outStr += """
+for _%(name)s_obj in [%(objects)s]:
+    if pysnmp_version < (4, 4, 2):
+        # WARNING: leading objects get lost here! Upgrade your pysnmp version!
+        %(name)s = %(name)s.setObjects(*_%(name)s_obj)
+    else:
+        %(name)s = %(name)s.setObjects(*_%(name)s_obj, append=False)
+
+""" % dict(name=name, objects=', '.join(objStrParts))
+
+            else:
+                outStr += '.setObjects(' + ', '.join(objects) + ')\n'
 
 # TODO: pysnmp does not implement .setStatus
 #        if status:
@@ -433,10 +447,24 @@ class PySnmpCodeGen(AbstractCodeGen):
 
             numFuncCalls = len(objects) // 255 + 1
 
-            for idx in range(numFuncCalls):
-                outStr += '.setObjects(' + ', '.join(objects[255 * idx:255 * (idx + 1)]) + ')'
+            if numFuncCalls > 1:
+                objStrParts = []
 
-            outStr += '\n'
+                for idx in range(numFuncCalls):
+                    objStrParts.append('[' + ', '.join(objects[255 * idx:255 * (idx + 1)]) + ']')
+
+                outStr += """
+for _%(name)s_obj in [%(objects)s]:
+    if pysnmp_version < (4, 4, 2):
+        # WARNING: leading objects get lost here! Upgrade your pysnmp version!
+        %(name)s = %(name)s.setObjects(*_%(name)s_obj)
+    else:
+        %(name)s = %(name)s.setObjects(*_%(name)s_obj, append=False)
+
+""" % dict(name=name, objects=', '.join(objStrParts))
+
+            else:
+                outStr += '.setObjects(' + ', '.join(objects) + ')\n'
 
         if status:
             outStr += self.ifTextStr + name + status + '\n'
@@ -468,10 +496,24 @@ class PySnmpCodeGen(AbstractCodeGen):
 
             numFuncCalls = len(objects) // 255 + 1
 
-            for idx in range(numFuncCalls):
-                outStr += '.setObjects(' + ', '.join(objects[255 * idx:255 * (idx + 1)]) + ')'
+            if numFuncCalls > 1:
+                objStrParts = []
 
-            outStr += '\n'
+                for idx in range(numFuncCalls):
+                    objStrParts.append('[' + ', '.join(objects[255 * idx:255 * (idx + 1)]) + ']')
+
+                outStr += """
+for _%(name)s_obj in [%(objects)s]:
+    if pysnmp_version < (4, 4, 2):
+        # WARNING: leading objects get lost here!
+        %(name)s = %(name)s.setObjects(*_%(name)s_obj)
+    else:
+        %(name)s = %(name)s.setObjects(*_%(name)s_obj, append=False)
+
+""" % dict(name=name, objects=', '.join(objStrParts))
+
+            else:
+                outStr += '.setObjects(' + ', '.join(objects) + ')\n'
 
 # TODO: pysnmp does not implement .setStatus
 #        if self.genRules['text'] and status:
@@ -575,10 +617,24 @@ class PySnmpCodeGen(AbstractCodeGen):
 
             numFuncCalls = len(objects) // 255 + 1
 
-            for idx in range(numFuncCalls):
-                outStr += '.setObjects(' + ', '.join(objects[255 * idx:255 * (idx + 1)]) + ')'
+            if numFuncCalls > 1:
+                objStrParts = []
 
-            outStr += '\n'
+                for idx in range(numFuncCalls):
+                    objStrParts.append('[' + ', '.join(objects[255 * idx:255 * (idx + 1)]) + ']')
+
+                outStr += """
+for _%(name)s_obj in [%(objects)s]:
+    if pysnmp_version < (4, 4, 2):
+        # WARNING: leading objects get lost here! Upgrade your pysnmp version!
+        %(name)s = %(name)s.setObjects(*_%(name)s_obj)
+    else:
+        %(name)s = %(name)s.setObjects(*_%(name)s_obj, append=False)
+
+""" % dict(name=name, objects=', '.join(objStrParts))
+
+            else:
+                outStr += '.setObjects(' + ', '.join(objects) + ')\n'
 
         if self.genRules['text'] and description:
             outStr += self.ifTextStr + name + description + '\n'
@@ -662,10 +718,24 @@ class PySnmpCodeGen(AbstractCodeGen):
 
         numFuncCalls = len(objects) // 255 + 1
 
-        for idx in range(numFuncCalls):
-            outStr += '.setObjects(' + ', '.join(objects[255 * idx:255 * (idx + 1)]) + ')'
+        if numFuncCalls > 1:
+            objStrParts = []
 
-        outStr += '\n'
+            for idx in range(numFuncCalls):
+                objStrParts.append('[' + ', '.join(objects[255 * idx:255 * (idx + 1)]) + ']')
+
+            outStr += """
+for _%(name)s_obj in [%(objects)s]:
+    if pysnmp_version < (4, 4, 2):
+        # WARNING: leading objects get lost here! Upgrade your pysnmp version!
+        %(name)s = %(name)s.setObjects(*_%(name)s_obj)
+    else:
+        %(name)s = %(name)s.setObjects(*_%(name)s_obj, append=False)
+
+""" % dict(name=name, objects=', '.join(objStrParts))
+
+        else:
+            outStr += '.setObjects(' + ', '.join(objects) + ')\n'
 
         return outStr
 
@@ -1071,6 +1141,8 @@ class PySnmpCodeGen(AbstractCodeGen):
             out += self._out[sym]
 
         out += self.genExports()
+
+        out = '\nfrom pysnmp import __version__ as pysnmp_version\n\n' + out
 
         if 'comments' in kwargs:
             out = ''.join(['# %s\n' % x for x in kwargs['comments']]) + '#\n' + out


### PR DESCRIPTION
This PR brings a handful of fixes to make sure that pysnmp codegen does not produce more than 255 params in func calls what makes generated Python code failing to compile.