### PR TITLE
Export some more data from MIB

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,9 @@
 
-Revision 0.1.5, XX-10-2017
+Revision 0.1.5, XX-11-2017
 --------------------------
 
+- Added MIB *status*, *release* and *revision description* set calls
+  at pysnmp code generator
 - Sphinx documentation theme changed to Alabaster
 
 Revision 0.1.4, 14-10-2017

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,9 +1,11 @@
 
-Revision 0.1.5, XX-11-2017
+Revision 0.2.1, XX-11-2017
 --------------------------
 
 - Added MIB *status*, *release* and *revision description* set calls
   at pysnmp code generator
+- Changed REVISION field format in JSON representation - it is now
+  a list of dicts each with *revision* timestamp and *description* text
 - MIB REFERENCE fields are only exported if --with-mib-text is on
 - Sphinx documentation theme changed to Alabaster
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,8 +2,8 @@
 Revision 0.2.1, XX-11-2017
 --------------------------
 
-- Added MIB *status*, *release* and *revision description* set calls
-  at pysnmp code generator
+- Added MIB *status*, *product release* and *revision description* set
+  calls at pysnmp code generator
 - Changed REVISION field format in JSON representation - it is now
   a list of dicts each with *revision* timestamp and *description* text
 - MIB REFERENCE fields are only exported if --with-mib-text is on

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Revision 0.1.5, XX-11-2017
 
 - Added MIB *status*, *release* and *revision description* set calls
   at pysnmp code generator
+- MIB REFERENCE fields are only exported if --with-mib-text is on
 - Sphinx documentation theme changed to Alabaster
 
 Revision 0.1.4, 14-10-2017

--- a/pysmi/__init__.py
+++ b/pysmi/__init__.py
@@ -1,5 +1,5 @@
 # http://www.python.org/dev/peps/pep-0396/
-__version__ = '0.1.5'
+__version__ = '0.2.1'
 
 import sys
 

--- a/pysmi/codegen/jsondoc.py
+++ b/pysmi/codegen/jsondoc.py
@@ -76,7 +76,7 @@ class JsonCodeGen(AbstractCodeGen):
         self._oids = set()
         self._complianceOids = []
         self.moduleName = ['DUMMY']
-        self.genRules = {'text': 1}
+        self.genRules = {'text': True}
         self.symbolTable = {}
 
     @staticmethod

--- a/pysmi/codegen/jsondoc.py
+++ b/pysmi/codegen/jsondoc.py
@@ -228,7 +228,7 @@ class JsonCodeGen(AbstractCodeGen):
 
     # noinspection PyUnusedLocal
     def genAgentCapabilities(self, data):
-        name, product_release, status, description, reference, oid = data
+        name, productRelease, status, description, reference, oid = data
 
         label = self.genLabel(name)
         name = self.transOpers(name)
@@ -240,8 +240,8 @@ class JsonCodeGen(AbstractCodeGen):
         outDict['oid'] = oidStr
         outDict['class'] = 'agentcapabilities'
 
-        if product_release:
-            outDict['release'] = product_release
+        if productRelease:
+            outDict['productrelease'] = productRelease
 
         if status:
             outDict['status'] = status

--- a/pysmi/codegen/jsondoc.py
+++ b/pysmi/codegen/jsondoc.py
@@ -802,8 +802,13 @@ class JsonCodeGen(AbstractCodeGen):
 
     # noinspection PyUnusedLocal
     def genRevisions(self, data):
-        times = self.genTime([x[0] for x in data[0]])
-        return times
+        revisions = []
+        for x in data[0]:
+            revision = OrderedDict()
+            revision['revision'] = self.genTime([x[0]])[0]
+            revision['description'] = self.textFilter('description', x[1][1])
+            revisions.append(revision)
+        return revisions
 
     def genRow(self, data):
         row = data[0]

--- a/pysmi/codegen/jsondoc.py
+++ b/pysmi/codegen/jsondoc.py
@@ -249,7 +249,7 @@ class JsonCodeGen(AbstractCodeGen):
         if self.genRules['text'] and description:
             outDict['description'] = description
 
-        if reference:
+        if self.genRules['text'] and reference:
             outDict['reference'] = reference
 
         self.regSym(name, outDict, parentOid)
@@ -310,7 +310,7 @@ class JsonCodeGen(AbstractCodeGen):
         if self.genRules['text'] and description:
             outDict['description'] = description
 
-        if reference:
+        if self.genRules['text'] and reference:
             outDict['reference'] = reference
 
         self.regSym(name, outDict, parentOid, moduleCompliance=True)
@@ -339,7 +339,7 @@ class JsonCodeGen(AbstractCodeGen):
         if self.genRules['text'] and description:
             outDict['description'] = description
 
-        if reference:
+        if self.genRules['text'] and reference:
             outDict['reference'] = reference
 
         self.regSym(name, outDict, parentOid)
@@ -368,7 +368,7 @@ class JsonCodeGen(AbstractCodeGen):
         if self.genRules['text'] and description:
             outDict['description'] = description
 
-        if reference:
+        if self.genRules['text'] and reference:
             outDict['reference'] = reference
 
         self.regSym(name, outDict, parentOid)
@@ -396,7 +396,7 @@ class JsonCodeGen(AbstractCodeGen):
         if self.genRules['text'] and description:
             outDict['description'] = description
 
-        if reference:
+        if self.genRules['text'] and reference:
             outDict['reference'] = reference
 
         self.regSym(name, outDict, parentOid)
@@ -423,7 +423,7 @@ class JsonCodeGen(AbstractCodeGen):
         if self.genRules['text'] and description:
             outDict['description'] = description
 
-        if reference:
+        if self.genRules['text'] and reference:
             outDict['reference'] = reference
 
         self.regSym(name, outDict, parentOid)
@@ -463,7 +463,7 @@ class JsonCodeGen(AbstractCodeGen):
             outDict['maxaccess'] = maxaccess
         if indexStr:
             outDict['indices'] = indexStr
-        if reference:
+        if self.genRules['text'] and reference:
             outDict['reference'] = reference
         if augmention:
             augmention = self.transOpers(augmention)
@@ -506,7 +506,7 @@ class JsonCodeGen(AbstractCodeGen):
         if self.genRules['text'] and description:
             outDict['description'] = description
 
-        if reference:
+        if self.genRules['text'] and reference:
             outDict['reference'] = reference
 
         self.regSym(name, outDict, parentOid)
@@ -859,7 +859,7 @@ class JsonCodeGen(AbstractCodeGen):
                 outDict['status'] = status
             if self.genRules['text'] and description:
                 outDict['description'] = description
-            if reference:
+            if self.genRules['text'] and reference:
                 outDict['reference'] = reference
 
         return parentType, outDict

--- a/pysmi/codegen/pysnmp.py
+++ b/pysmi/codegen/pysnmp.py
@@ -117,7 +117,7 @@ class PySnmpCodeGen(AbstractCodeGen):
         self._out = {}  # k, v = name, generated code
         self._moduleIdentityOid = None
         self.moduleName = ['DUMMY']
-        self.genRules = {'text': 1}
+        self.genRules = {'text': True}
         self.symbolTable = {}
 
     def symTrans(self, symbol):
@@ -305,13 +305,13 @@ class PySnmpCodeGen(AbstractCodeGen):
 
         if productRelease:
             outStr += """\
-if getattr(mibBuilder, 'version', 0) > (4, 4, 0):
+if getattr(mibBuilder, 'version', (0, 0, 0)) > (4, 4, 0):
     %(name)s = %(name)s%(productRelease)s
 """ % dict(name=name, release=productRelease)
 
         if status:
             outStr += """\
-if getattr(mibBuilder, 'version', 0) > (4, 4, 0):
+if getattr(mibBuilder, 'version', (0, 0, 0)) > (4, 4, 0):
     %(name)s = %(name)s%(status)s
 """ % dict(name=name, status=status)
 
@@ -344,7 +344,7 @@ if getattr(mibBuilder, 'version', 0) > (4, 4, 0):
 
             if self.genRules['text'] and descriptions:
                 outStr += """
-if getattr(mibBuilder, 'version', 0) > (4, 4, 0):
+if getattr(mibBuilder, 'version', (0, 0, 0)) > (4, 4, 0):
     %(ifTextStr)s%(name)s%(descriptions)s
 """ % dict(ifTextStr=self.ifTextStr, name=name, descriptions=descriptions)
 
@@ -377,7 +377,7 @@ if getattr(mibBuilder, 'version', 0) > (4, 4, 0):
 
         if status:
             outStr += """\
-if getattr(mibBuilder, 'version', 0) > (4, 4, 0):
+if getattr(mibBuilder, 'version', (0, 0, 0)) > (4, 4, 0):
     %(name)s = %(name)s%(status)s
 """ % dict(name=name, status=status)
 
@@ -409,7 +409,7 @@ if getattr(mibBuilder, 'version', 0) > (4, 4, 0):
 
         if status:
             outStr += """\
-if getattr(mibBuilder, 'version', 0) > (4, 4, 0):
+if getattr(mibBuilder, 'version', (0, 0, 0)) > (4, 4, 0):
     %(name)s = %(name)s%(status)s
 """ % dict(name=name, status=status)
 
@@ -470,7 +470,7 @@ if getattr(mibBuilder, 'version', 0) > (4, 4, 0):
 
         if status:
             outStr += """\
-if getattr(mibBuilder, 'version', 0) > (4, 4, 0):
+if getattr(mibBuilder, 'version', (0, 0, 0)) > (4, 4, 0):
     %(name)s = %(name)s%(status)s
 """ % dict(name=name, status=status)
 

--- a/pysmi/codegen/pysnmp.py
+++ b/pysmi/codegen/pysnmp.py
@@ -295,7 +295,7 @@ class PySnmpCodeGen(AbstractCodeGen):
 
     # noinspection PyUnusedLocal
     def genAgentCapabilities(self, data, classmode=False):
-        name, release, status, description, reference, oid = data
+        name, productRelease, status, description, reference, oid = data
 
         label = self.genLabel(name)
         name = self.transOpers(name)
@@ -303,22 +303,22 @@ class PySnmpCodeGen(AbstractCodeGen):
         oidStr, parentOid = oid
         outStr = name + ' = AgentCapabilities(' + oidStr + ')' + label + '\n'
 
-        if release:
+        if productRelease:
             outStr += """\
-if getattr(mibBuilder, 'version', 0) > (4, 3, 5):
-    %(name)s = %(name)s%(release)s
-""" % dict(name=name, release=release)
+if getattr(mibBuilder, 'version', 0) > (4, 4, 0):
+    %(name)s = %(name)s%(productRelease)s
+""" % dict(name=name, release=productRelease)
 
         if status:
             outStr += """\
-if getattr(mibBuilder, 'version', 0) > (4, 3, 5):
+if getattr(mibBuilder, 'version', 0) > (4, 4, 0):
     %(name)s = %(name)s%(status)s
 """ % dict(name=name, status=status)
 
         if self.genRules['text'] and description:
             outStr += self.ifTextStr + name + description + '\n'
 
-        if reference:
+        if self.genRules['text'] and reference:
             outStr += name + reference + '\n'
 
         self.regSym(name, outStr, oidStr)
@@ -377,7 +377,7 @@ if getattr(mibBuilder, 'version', 0) > (4, 4, 0):
 
         if status:
             outStr += """\
-if getattr(mibBuilder, 'version', 0) > (4, 3, 5):
+if getattr(mibBuilder, 'version', 0) > (4, 4, 0):
     %(name)s = %(name)s%(status)s
 """ % dict(name=name, status=status)
 
@@ -409,7 +409,7 @@ if getattr(mibBuilder, 'version', 0) > (4, 3, 5):
 
         if status:
             outStr += """\
-if getattr(mibBuilder, 'version', 0) > (4, 3, 5):
+if getattr(mibBuilder, 'version', 0) > (4, 4, 0):
     %(name)s = %(name)s%(status)s
 """ % dict(name=name, status=status)
 
@@ -470,7 +470,7 @@ if getattr(mibBuilder, 'version', 0) > (4, 3, 5):
 
         if status:
             outStr += """\
-if getattr(mibBuilder, 'version', 0) > (4, 3, 5):
+if getattr(mibBuilder, 'version', 0) > (4, 4, 0):
     %(name)s = %(name)s%(status)s
 """ % dict(name=name, status=status)
 
@@ -756,7 +756,7 @@ if getattr(mibBuilder, 'version', 0) > (4, 3, 5):
     # noinspection PyMethodMayBeStatic
     def genProductRelease(self, data, classmode=False):
         text = data[0]
-        return classmode and self.indent + 'release = ' + dorepr(text) + '\n' or '.setRelease(' + dorepr(text) + ')'
+        return classmode and self.indent + 'productRelease = ' + dorepr(text) + '\n' or '.setProductRelease(' + dorepr(text) + ')'
 
     def genEnumSpec(self, data, classmode=False):
         items = data[0]

--- a/pysmi/codegen/pysnmp.py
+++ b/pysmi/codegen/pysnmp.py
@@ -342,7 +342,7 @@ if getattr(mibBuilder, 'version', 0) > (4, 3, 5):
             if revisions:
                 outStr += name + revisions + '\n'
 
-            if descriptions:
+            if self.genRules['text'] and descriptions:
                 outStr += """
 if getattr(mibBuilder, 'version', 0) > (4, 4, 0):
     %(ifTextStr)s%(name)s%(descriptions)s
@@ -351,7 +351,7 @@ if getattr(mibBuilder, 'version', 0) > (4, 4, 0):
         if lastUpdated:
             outStr += self.ifTextStr + name + lastUpdated + '\n'
 
-        if self.genRules['text'] and organization:
+        if organization:
             outStr += self.ifTextStr + name + organization + '\n'
 
         if self.genRules['text'] and contactInfo:
@@ -384,7 +384,7 @@ if getattr(mibBuilder, 'version', 0) > (4, 3, 5):
         if self.genRules['text'] and description:
             outStr += self.ifTextStr + name + description + '\n'
 
-        if reference:
+        if self.genRules['text'] and reference:
             outStr += self.ifTextStr + name + reference + '\n'
 
         self.regSym(name, outStr, oidStr)
@@ -416,7 +416,7 @@ if getattr(mibBuilder, 'version', 0) > (4, 3, 5):
         if self.genRules['text'] and description:
             outStr += self.ifTextStr + name + description + '\n'
 
-        if reference:
+        if self.genRules['text'] and reference:
             outStr += name + reference + '\n'
 
         self.regSym(name, outStr, oidStr)
@@ -445,7 +445,7 @@ if getattr(mibBuilder, 'version', 0) > (4, 3, 5):
         if self.genRules['text'] and description:
             outStr += self.ifTextStr + name + description + '\n'
 
-        if reference:
+        if self.genRules['text'] and reference:
             outStr += self.ifTextStr + name + reference + '\n'
 
         self.regSym(name, outStr, oidStr)
@@ -477,7 +477,7 @@ if getattr(mibBuilder, 'version', 0) > (4, 3, 5):
         if self.genRules['text'] and description:
             outStr += self.ifTextStr + name + description + '\n'
 
-        if reference:
+        if self.genRules['text'] and reference:
             outStr += self.ifTextStr + name + reference + '\n'
 
         self.regSym(name, outStr, oidStr)
@@ -500,7 +500,7 @@ if getattr(mibBuilder, 'version', 0) > (4, 3, 5):
         if self.genRules['text'] and description:
             outStr += self.ifTextStr + name + description + '\n'
 
-        if reference:
+        if self.genRules['text'] and reference:
             outStr += self.ifTextStr + name + reference + '\n'
 
         self.regSym(name, outStr, oidStr)
@@ -532,7 +532,7 @@ if getattr(mibBuilder, 'version', 0) > (4, 3, 5):
         outStr += indexStr or ''
         outStr += '\n'
 
-        if reference:
+        if self.genRules['text'] and reference:
             outStr += self.ifTextStr + name + reference + '\n'
 
         if augmention:
@@ -575,7 +575,7 @@ if getattr(mibBuilder, 'version', 0) > (4, 3, 5):
         if self.genRules['text'] and description:
             outStr += self.ifTextStr + name + description + '\n'
 
-        if reference:
+        if self.genRules['text'] and reference:
             outStr += self.ifTextStr + name + reference + '\n'
 
         self.regSym(name, outStr, enterpriseStr)

--- a/pysmi/codegen/symtable.py
+++ b/pysmi/codegen/symtable.py
@@ -88,7 +88,7 @@ class SymtableCodeGen(AbstractCodeGen):
         self._symsOrder = []
         self._out = {}  # k, v = symbol, properties
         self.moduleName = ['DUMMY']
-        self.genRules = {'text': 1}
+        self.genRules = {'text': True}
 
     def symTrans(self, symbol):
         if symbol in self.symsTable:


### PR DESCRIPTION
This PR  adds conditional support for some more of the missing SMIv2 MACRO fields export to pysnmp code generator. Specifically, these are *STATUS*, *REVISION* and *PRODUCT RELEASE*.

Besides that, *REFERENCE* field treated the same way as *DESCRIPTION* e.g. only exported if *--generate-mib-texts* option is in effect.

