### PR TITLE
mibcopy.py tool implemented

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,12 +1,16 @@
 
-Revision 0.3.0, XX-02-2018
+Revision 0.3.0, XX-04-2018
 --------------------------
 
+- The `mibcopy` tool implemented to copy MIB modules from files with
+  potentially messed up names into a directory under canonical MIB
+  names picking up the latest MIB revision along the way.
 - ZIP archive reader implemented to pull ASN.1 MIB files from .zip
   archives pretty much in the same way as from plain directories
 - Copyright notice bumped up to year 2018
 - Project site in the docs changes from SourceForge to snmplabs.com
 - PRODUCT-RELEASE generation added to the JSON code generator
+- Fixed missing REVISIONS generations in MODULE-IDENTITY
 
 Revision 0.2.2, 13-11-2017
 --------------------------

--- a/pysmi/codegen/jsondoc.py
+++ b/pysmi/codegen/jsondoc.py
@@ -72,6 +72,7 @@ class JsonCodeGen(AbstractCodeGen):
         self._importMap = {}
         self._out = {}  # k, v = name, generated code
         self._moduleIdentityOid = None
+        self._moduleRevision = None
         self._enterpriseOid = None
         self._oids = set()
         self._complianceOids = []
@@ -272,6 +273,8 @@ class JsonCodeGen(AbstractCodeGen):
 
         if revisions:
             outDict['revisions'] = revisions
+
+            self._moduleRevision = revisions[0]['revision']
 
         if self.genRules['text']:
             if lastUpdated:
@@ -960,6 +963,7 @@ class JsonCodeGen(AbstractCodeGen):
         return MibInfo(oid=moduleOid,
                        identity=self._moduleIdentityOid,
                        name=self.moduleName[0],
+                       revision=self._moduleRevision,
                        oids=self._oids,
                        enterprise=self._enterpriseOid,
                        compliance=self._complianceOids,

--- a/pysmi/codegen/pysnmp.py
+++ b/pysmi/codegen/pysnmp.py
@@ -116,6 +116,7 @@ class PySnmpCodeGen(AbstractCodeGen):
         self._importMap = {}
         self._out = {}  # k, v = name, generated code
         self._moduleIdentityOid = None
+        self._moduleRevision = None
         self.moduleName = ['DUMMY']
         self.genRules = {'text': True}
         self.symbolTable = {}
@@ -340,7 +341,9 @@ if getattr(mibBuilder, 'version', (0, 0, 0)) > (4, 4, 0):
         outStr = name + ' = ModuleIdentity(' + oidStr + ')' + label + '\n'
 
         if revisionsAndDescrs:
-            revisions, descriptions = revisionsAndDescrs
+            last_revision, revisions, descriptions = revisionsAndDescrs
+
+            self._moduleRevision = last_revision
 
             if revisions:
                 outStr += name + revisions + '\n'
@@ -1030,7 +1033,9 @@ for _%(name)s_obj in [%(objects)s]:
             [dorepr(self.textFilter('description', x[1][1])) for x in data[0]]
         )
 
-        return revisions, descriptions
+        lastRevision = data[0][0][0]
+
+        return lastRevision, revisions, descriptions
 
     def genRow(self, data, classmode=False):
         row = data[0]
@@ -1177,6 +1182,7 @@ for _%(name)s_obj in [%(objects)s]:
         return MibInfo(oid=moduleOid,
                        identity=self._moduleIdentityOid,
                        name=self.moduleName[0],
+                       revision=self._moduleRevision,
                        oids=[],
                        enterprise=None,
                        compliance=[],

--- a/pysmi/codegen/symtable.py
+++ b/pysmi/codegen/symtable.py
@@ -88,6 +88,7 @@ class SymtableCodeGen(AbstractCodeGen):
         self._symsOrder = []
         self._out = {}  # k, v = symbol, properties
         self.moduleName = ['DUMMY']
+        self._moduleRevision = None
         self.genRules = {'text': True}
 
     def symTrans(self, symbol):
@@ -219,6 +220,9 @@ class SymtableCodeGen(AbstractCodeGen):
         symProps = {'type': 'ModuleIdentity',
                     'oid': oid,
                     'origName': origName}
+
+        if revisions:
+            self._moduleRevision = revisions[0]
 
         self.regSym(pysmiName, symProps)
 
@@ -491,15 +495,16 @@ class SymtableCodeGen(AbstractCodeGen):
 
     # noinspection PyUnusedLocal,PyUnusedLocal,PyMethodMayBeStatic
     def genLastUpdated(self, data, classmode=False):
-        return ''
+        return data[0]
 
     # noinspection PyUnusedLocal,PyUnusedLocal,PyMethodMayBeStatic
     def genOrganization(self, data, classmode=False):
-        return ''
+        return data[0]
 
     # noinspection PyUnusedLocal,PyUnusedLocal,PyMethodMayBeStatic
     def genRevisions(self, data, classmode=False):
-        return ''
+        lastRevision, lastDescription = data[0][0][0], data[0][0][1][1]
+        return lastRevision, lastDescription
 
     def genRow(self, data, classmode=False):
         row = data[0]
@@ -622,4 +627,7 @@ class SymtableCodeGen(AbstractCodeGen):
             'canonical MIB name %s (%s), imported MIB(s) %s, Symbol table size %s symbols' % (
                 self.moduleName[0], moduleOid, ','.join(importedModules) or '<none>', len(self._out)))
 
-        return MibInfo(oid=None, name=self.moduleName[0], imported=tuple([x for x in importedModules])), self._out
+        return MibInfo(oid=None,
+                       name=self.moduleName[0],
+                       revision=self._moduleRevision,
+                       imported=tuple([x for x in importedModules])), self._out

--- a/pysmi/mibinfo.py
+++ b/pysmi/mibinfo.py
@@ -25,6 +25,9 @@ class MibInfo(object):
     #: module OID
     oid = ''
 
+    #: MIB revision as `datetime`
+    revision = None
+
     #: all OIDs defined in this module
     oids = ()
 

--- a/scripts/mibcopy.py
+++ b/scripts/mibcopy.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python
+#
+# This file is part of pysmi software.
+#
+# Copyright (c) 2015-2018, Ilya Etingof <etingof@gmail.com>
+# License: http://snmplabs.com/pysmi/license.html
+#
+# SNMP SMI/MIB copying tool
+#
+import os
+import sys
+import getopt
+import shutil
+from datetime import datetime
+from pysmi.reader import FileReader, getReadersFromUrls
+from pysmi.writer import CallbackWriter
+from pysmi.parser import SmiV1CompatParser
+from pysmi.codegen import JsonCodeGen
+from pysmi.compiler import MibCompiler
+from pysmi import debug
+from pysmi import error
+
+
+# Defaults
+quietFlag = False
+verboseFlag = False
+mibSources = []
+dstDirectory = None
+cacheDirectory = ''
+dryrunFlag = False
+ignoreErrorsFlag = False
+
+helpMessage = """\
+Usage: %s [--help]
+      [--version]
+      [--verbose]
+      [--quiet]
+      [--debug=<%s>]
+      [--mib-source=<URI>]
+      [--cache-directory=<DIRECTORY>]
+      [--ignore-errors]
+      [--dry-run]
+      <SOURCE [SOURCE...]> <DESTINATION>
+Where:
+    URI      - file, zip, http, https, ftp, sftp schemes are supported.
+               Use @mib@ placeholder token in URI to refer directly to
+               the required MIB module when source does not support
+               directory listing (e.g. HTTP).
+""" % (
+    sys.argv[0],
+    '|'.join([x for x in sorted(debug.flagMap)])
+)
+
+# TODO(etingof): add the option to copy MIBs into enterprise-indexed subdirs
+
+try:
+    opts, inputMibs = getopt.getopt(
+        sys.argv[1:], 'hv',
+        ['help', 'version', 'verbose', 'quiet', 'debug=',
+         'mib-source=', 'mib-stub=',
+         'cache-directory=', 'ignore-errors', 'dry-run']
+    )
+
+except getopt.GetoptError:
+    sys.exit(1)
+
+for opt in opts:
+    if opt[0] == '-h' or opt[0] == '--help':
+        sys.stderr.write("""\
+Synopsis:
+  SNMP SMI/MIB files copying tool. When given MIB file(s) or directory(ies)
+  on input and a destination directory, the tool parses MIBs to figure out
+  their canonical MIB module name and the latest revision date, then
+  copies MIB module on input into the destination directory under its
+  MIB module name *if* there is no such file already or its revision date
+  is older.
+
+Documentation:
+  http://snmplabs.com/pysmi
+%s
+""" % helpMessage)
+        sys.exit(1)
+
+    if opt[0] == '-v' or opt[0] == '--version':
+        from pysmi import __version__
+
+        sys.stderr.write("""\
+SNMP SMI/MIB library version %s, written by Ilya Etingof <etingof@gmail.com>
+Python interpreter: %s
+Software documentation and support at http://snmplabs.com/pysmi
+%s
+""" % (__version__, sys.version, helpMessage))
+        sys.exit(1)
+
+    if opt[0] == '--quiet':
+        quietFlag = True
+
+    if opt[0] == '--verbose':
+        verboseFlag = True
+
+    if opt[0] == '--debug':
+        debug.setLogger(debug.Debug(*opt[1].split(',')))
+
+    if opt[0] == '--mib-source':
+        mibSources.append(opt[1])
+
+    if opt[0] == '--cache-directory':
+        cacheDirectory = opt[1]
+
+    if opt[0] == '--ignore-errors':
+        ignoreErrorsFlag = True
+
+if not mibSources:
+    mibSources = ['file:///usr/share/snmp/mibs',
+                  'http://mibs.snmplabs.com/asn1/@mib@']
+
+if len(inputMibs) < 2:
+    sys.stderr.write('ERROR: MIB source and/or destination arguments not given\r\n%s\r\n' % helpMessage)
+    sys.exit(1)
+
+dstDirectory = inputMibs.pop()
+
+if os.path.exists(dstDirectory) and not os.path.isdir(dstDirectory):
+    sys.stderr.write('ERROR: given destination is not a directory\r\n%s\r\n' % helpMessage)
+    sys.exit(1)
+
+try:
+    os.makedirs(dstDirectory, mode=0o755)
+
+except OSError:
+    pass
+
+# Compiler infrastructure
+
+codeGenerator = JsonCodeGen()
+
+mibParser = SmiV1CompatParser(tempdir=cacheDirectory)
+
+fileWriter = CallbackWriter(lambda *x: None)
+
+
+def getMibRevision(mibDir, mibFile):
+
+    mibCompiler = MibCompiler(
+        mibParser,
+        codeGenerator,
+        fileWriter
+    )
+
+    mibCompiler.addSources(
+        FileReader(mibDir, recursive=False, ignoreErrors=ignoreErrorsFlag),
+        *getReadersFromUrls(*mibSources)
+    )
+
+    try:
+        processed = mibCompiler.compile(
+            mibFile, **dict(noDeps=True, rebuild=True, fuzzyMatching=False, ignoreErrors=ignoreErrorsFlag)
+        )
+
+    except error.PySmiError:
+        sys.stderr.write('ERROR: %s\r\n' % sys.exc_info()[1])
+        sys.exit(-1)
+
+    for canonicalMibName in processed:
+        if (processed[canonicalMibName] == 'compiled' and
+                processed[canonicalMibName].path == 'file://' + os.path.join(mibDir, mibFile)):
+
+            try:
+                revision = datetime.strptime(processed[canonicalMibName].revision, '%Y-%m-%d %H:%M')
+
+            except Exception:
+                revision = datetime.fromtimestamp(0)
+
+            return canonicalMibName, revision
+
+    raise error.PySmiError('Can\'t read or parse MIB "%s"' % os.path.join(mibDir, mibFile))
+
+
+def shortenPath(path, maxLength=45):
+    if len(path) > maxLength:
+        return '...' + path[-maxLength:]
+    else:
+        return path
+
+mibsSeen = mibsCopied = mibsFailed = 0
+
+mibsRevisions = {}
+
+for srcDirectory in inputMibs:
+
+    if verboseFlag:
+        sys.stderr.write('Reading "%s"...\r\n' % srcDirectory)
+
+    if os.path.isfile(srcDirectory):
+        mibFiles = [(os.path.abspath(os.path.dirname(srcDirectory)), os.path.basename(srcDirectory))]
+
+    else:
+        mibFiles = [(os.path.abspath(dirName), mibFile)
+                    for dirName, _, mibFiles in os.walk(srcDirectory)
+                    for mibFile in mibFiles]
+
+    for srcDirectory, mibFile in mibFiles:
+
+        mibsSeen += 1
+
+        # TODO(etingof): also check module OID to make sure there is no name collision
+
+        try:
+            mibName, srcMibRevision = getMibRevision(srcDirectory, mibFile)
+
+        except error.PySmiError as ex:
+            if verboseFlag:
+                sys.stderr.write('Failed to read source MIB "%s": %s\r\n' % (os.path.join(srcDirectory, mibFile), ex))
+
+            if not quietFlag:
+                sys.stderr.write('FAILED %s\r\n' % shortenPath(os.path.join(srcDirectory, mibFile)))
+
+            mibsFailed +=1
+
+            continue
+
+        if mibName in mibsRevisions:
+            dstMibRevision = mibsRevisions[mibName]
+
+        else:
+            try:
+                _, dstMibRevision = getMibRevision(dstDirectory, mibName)
+
+            except error.PySmiError as ex:
+                if verboseFlag:
+                    sys.stderr.write('MIB "%s" is not available at the '
+                                     'destination directory "%s": %s\r\n' % (os.path.join(srcDirectory, mibFile),
+                                                                             dstDirectory, ex))
+
+                dstMibRevision = datetime.fromtimestamp(0)
+
+            mibsRevisions[mibName] = dstMibRevision
+
+        if dstMibRevision >= srcMibRevision:
+            if verboseFlag:
+                sys.stderr.write('Destination MIB "%s" has the same or newer revision as the '
+                                 'source MIB "%s"\r\n' % (os.path.join(dstDirectory, mibName),
+                                                          os.path.join(srcDirectory, mibFile)))
+            if not quietFlag:
+                sys.stderr.write('NOT COPIED %s (%s)\r\n' % (
+                    shortenPath(os.path.join(srcDirectory, mibFile)), mibName))
+
+            continue
+
+        mibsRevisions[mibName] = srcMibRevision
+
+        if verboseFlag:
+            sys.stderr.write('Copying "%s" (revision "%s") -> "%s" (revision "%s")\r\n' % (
+                os.path.join(srcDirectory, mibFile), srcMibRevision,
+                os.path.join(dstDirectory, mibName), dstMibRevision))
+
+        try:
+            shutil.copy(os.path.join(srcDirectory, mibFile), os.path.join(dstDirectory, mibName))
+
+        except Exception as ex:
+            if verboseFlag:
+                sys.stderr.write('Failed to copy MIB "%s" -> "%s" (%s): "%s"\r\n' % (
+                    os.path.join(srcDirectory, mibFile), os.path.join(dstDirectory, mibName), mibName, ex))
+
+            if not quietFlag:
+                sys.stderr.write('FAILED %s (%s)\r\n' % (
+                    shortenPath(os.path.join(srcDirectory, mibFile)), mibName))
+
+            mibsFailed += 1
+
+        else:
+            if not quietFlag:
+                sys.stderr.write('COPIED %s (%s)\r\n' % (
+                    shortenPath(os.path.join(srcDirectory, mibFile)), mibName))
+
+            mibsCopied +=1
+
+if not quietFlag:
+    sys.stderr.write("MIBs seen: %d, copied: %d, failed: %d\r\n" % (mibsSeen, mibsCopied, mibsFailed))

--- a/setup.py
+++ b/setup.py
@@ -113,7 +113,8 @@ params.update({
                  'pysmi.codegen',
                  'pysmi.borrower',
                  'pysmi.writer'],
-    'scripts': [os.path.join('scripts', 'mibdump.py')]
+    'scripts': [os.path.join('scripts', 'mibdump.py'),
+                os.path.join('scripts', 'mibcopy.py')]
 })
 
 # handle unittest discovery feature


### PR DESCRIPTION
The `mibcopy` tool implemented to copy MIB modules from files with potentially messed up names into a directory under canonical MIB names picking up the latest MIB revision along the way.

Also:

* REVISIONS handled in MODULE-IDENTITY
* MIB `revision` field added to MIB info reporting
* Subtle bug fixed in `noDeps` flag support
