### PR TITLE
Switch to urllib2

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@ Revision 0.3.0, XX-04-2018
   names picking up the latest MIB revision along the way.
 - ZIP archive reader implemented to pull ASN.1 MIB files from .zip
   archives pretty much in the same way as from plain directories
+- HTTP/S proxy support added (through respecting `http_proxy` environment
+  variable) by switching from `httplib` to `urllib2` internally
 - Copyright notice bumped up to year 2018
 - Project site in the docs changes from SourceForge to snmplabs.com
 - PRODUCT-RELEASE generation added to the JSON code generator

--- a/pysmi/reader/httpclient.py
+++ b/pysmi/reader/httpclient.py
@@ -88,9 +88,9 @@ class HttpReader(AbstractReader):
                 debug.logger & debug.flagReader and debug.logger('failed to fetch MIB from %s: %s' % (url, sys.exc_info()[1]))
                 continue
 
-            debug.logger & debug.flagReader and debug.logger('HTTP response %s' % response.status)
+            debug.logger & debug.flagReader and debug.logger('HTTP response %s' % response.code)
 
-            if response.status == 200:
+            if response.code == 200:
                 try:
                     mtime = time.mktime(time.strptime(response.getheader('Last-Modified'), "%a, %d %b %Y %H:%M:%S %Z"))
 


### PR DESCRIPTION
This patch replaces `httplib` with `urllib2` in the `httpreader` mainly to support HTTP/S proxy through respecting `http_proxy` environment variable by `urllib2`.

Note that `ftpreader` still relies on `ftplib` which is not proxy-aware.