### PR TITLE
Switch back to official Python 3.7 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,8 +32,8 @@ matrix:
     python: '3.6'
   - os: linux
     dist: xenial
-    sudo: false
-    python: '3.7-dev'
+    sudo: true
+    python: '3.7'
   - os: linux
     dist: xenial
     sudo: false


### PR DESCRIPTION
It appears that Python 3.7 use in Travis-CI is finally fixed. However,
it requires use of xenial distribution and sudo: true. Those have
now been added to the matrix.

Signed-off-by: Eric Brown <browne@vmware.com>