### PR TITLE
Fix MIB compilation with Python reserved keywords

### DIFF
--- a/pysmi/codegen/intermediate.py
+++ b/pysmi/codegen/intermediate.py
@@ -20,6 +20,8 @@ if sys.version_info[0] > 2:
     unicode = str
     long = int
 
+RESERVED_KEYWORDS_PREFIX = 'pysmi_'
+
 
 class IntermediateCodeGen(AbstractCodeGen):
     """Turns MIB AST into an intermediate representation.
@@ -1007,9 +1009,9 @@ class IntermediateCodeGen(AbstractCodeGen):
         for sym in self.symbolTable[self.moduleName[0]]['_symtable_order']:
             true_sym = sym
 
-            if sym.startswith("pysmi_"):
+            if sym.startswith(RESERVED_KEYWORDS_PREFIX):
                 # Removing prefix added for reserved keywords
-                true_sym = sym[6:]
+                true_sym = sym[len(RESERVED_KEYWORDS_PREFIX):]
 
             if true_sym not in self._out:
                 raise error.PySmiCodegenError('No generated code for symbol %s' % sym)

--- a/pysmi/codegen/intermediate.py
+++ b/pysmi/codegen/intermediate.py
@@ -1005,10 +1005,16 @@ class IntermediateCodeGen(AbstractCodeGen):
                 self.handlersTable[declr[0]](self, self.prepData(declr[1:]))
 
         for sym in self.symbolTable[self.moduleName[0]]['_symtable_order']:
-            if sym not in self._out:
+            true_sym = sym
+
+            if sym.startswith("pysmi_"):
+                # Removing prefix added for reserved keywords
+                true_sym = sym[6:]
+
+            if true_sym not in self._out:
                 raise error.PySmiCodegenError('No generated code for symbol %s' % sym)
 
-            outDict[sym] = self._out[sym]
+            outDict[sym] = self._out[true_sym]
 
         outDict['meta'] = OrderedDict()
         outDict['meta']['module'] = self.moduleName[0]


### PR DESCRIPTION
PySMI would fail to compile mibs that uses symbols that are Python reserved keywords. 
Because the underlying PySNMP MIB representation is stored in Python files, those symbols are prefixed with `pysmi_` [here](https://github.com/TCheruy/pysmi/blob/1f2391fc92b4a3ccc2c59aa14f459bd165c3a4aa/pysmi/codegen/symtable.py#L103).
However, this prefix need to be striped in [this check](https://github.com/etingof/pysmi/blob/58f2bf29cccff633af703f319dc237e17e16e3d3/pysmi/codegen/intermediate.py#L1008) for the compilation to complete. This PR handles this.